### PR TITLE
Fix AnalyzerOptions in DQDL rule converters

### DIFF
--- a/src/main/scala/com/amazon/deequ/dqdl/translation/DQDLRuleConverter.scala
+++ b/src/main/scala/com/amazon/deequ/dqdl/translation/DQDLRuleConverter.scala
@@ -16,20 +16,29 @@
 
 package com.amazon.deequ.dqdl.translation
 
+import com.amazon.deequ.analyzers.{AnalyzerOptions, FilteredRowOutcome, NullBehavior}
 import com.amazon.deequ.checks.Check
 import com.amazon.deequ.dqdl.execution.DefaultOperandEvaluator
 import com.amazon.deequ.dqdl.model.DeequMetricMapping
+import com.amazon.deequ.dqdl.util.DQDLUtility.isWhereClausePresent
 import software.amazon.glue.dqdl.model.DQRule
 import software.amazon.glue.dqdl.model.condition.number.NumberBasedCondition
 
 
 trait DQDLRuleConverter {
+
+  val DEFAULT_ANALYZER_OPTION: Option[AnalyzerOptions] =
+    Some(AnalyzerOptions(NullBehavior.EmptyString, FilteredRowOutcome.TRUE))
+
   def convert(rule: DQRule): Either[String, (Check, Seq[DeequMetricMapping])]
 
   def assertionAsScala(dqRule: DQRule, e: NumberBasedCondition): Double => Boolean = {
     val evaluator = DefaultOperandEvaluator
     (d: Double) => e.evaluate(d, dqRule, evaluator)
   }
+
+  protected def analyzerOptionsForWhereClause(rule: DQRule): Option[AnalyzerOptions] =
+    if (isWhereClausePresent(rule)) DEFAULT_ANALYZER_OPTION else None
 }
 
 

--- a/src/main/scala/com/amazon/deequ/dqdl/translation/rules/ColumnLengthRule.scala
+++ b/src/main/scala/com/amazon/deequ/dqdl/translation/rules/ColumnLengthRule.scala
@@ -59,15 +59,20 @@ case class ColumnLengthRule() extends DQDLRuleConverter {
     val operands = rawOperands.map(_.getOperand.toDouble)
     val transformedColForSparkSql = if (requiresToBeQuoted(targetColumn)) s"`$targetColumn`" else targetColumn
 
-    def withMultipleConstraints(minAssertion: Double => Boolean, maxAssertion: Double => Boolean): Check = {
+    val opts = DEFAULT_ANALYZER_OPTION
+
+    def withMultipleConstraints(minAssertion: Double => Boolean,
+                                maxAssertion: Double => Boolean): Check = {
       if (isWhereClausePresent(rule)) {
         check
-          .hasMinLength(targetColumn, minAssertion).where(rule.getWhereClause)
-          .hasMaxLength(targetColumn, maxAssertion).where(rule.getWhereClause)
+          .hasMinLength(targetColumn, minAssertion, analyzerOptions = opts)
+          .where(rule.getWhereClause)
+          .hasMaxLength(targetColumn, maxAssertion, analyzerOptions = opts)
+          .where(rule.getWhereClause)
       } else {
         check
-          .hasMinLength(targetColumn, minAssertion)
-          .hasMaxLength(targetColumn, maxAssertion)
+          .hasMinLength(targetColumn, minAssertion, analyzerOptions = opts)
+          .hasMaxLength(targetColumn, maxAssertion, analyzerOptions = opts)
       }
     }
 
@@ -76,16 +81,20 @@ case class ColumnLengthRule() extends DQDLRuleConverter {
         Right(withMultipleConstraints(_ > operands.head, _ < operands.last))
 
       case GREATER_THAN_EQUAL_TO =>
-        Right(addWhereClause(rule, check.hasMinLength(targetColumn, _ >= operands.head)))
+        Right(addWhereClause(rule, check.hasMinLength(targetColumn, _ >= operands.head,
+          analyzerOptions = opts)))
 
       case GREATER_THAN =>
-        Right(addWhereClause(rule, check.hasMinLength(targetColumn, _ > operands.head)))
+        Right(addWhereClause(rule, check.hasMinLength(targetColumn, _ > operands.head,
+          analyzerOptions = opts)))
 
       case LESS_THAN_EQUAL_TO =>
-        Right(addWhereClause(rule, check.hasMaxLength(targetColumn, _ <= operands.head)))
+        Right(addWhereClause(rule, check.hasMaxLength(targetColumn, _ <= operands.head,
+          analyzerOptions = opts)))
 
       case LESS_THAN =>
-        Right(addWhereClause(rule, check.hasMaxLength(targetColumn, _ < operands.head)))
+        Right(addWhereClause(rule, check.hasMaxLength(targetColumn, _ < operands.head,
+          analyzerOptions = opts)))
 
       case EQUALS =>
         Right(withMultipleConstraints(_ == operands.head, _ == operands.head))
@@ -103,7 +112,7 @@ case class ColumnLengthRule() extends DQDLRuleConverter {
               s"length($transformedColForSparkSql) in (${operands.mkString(",")})"
           }
         Right(addWhereClause(rule, check.satisfies(complianceCondition, check.description, _ == 1.0,
-          columns = List(transformedColForSparkSql))))
+          columns = List(transformedColForSparkSql), analyzerOptions = opts)))
 
       case NOT_IN =>
         val complianceCondition =
@@ -115,7 +124,7 @@ case class ColumnLengthRule() extends DQDLRuleConverter {
               s"length($transformedColForSparkSql) not in (${operands.mkString(",")})"
           }
         Right(addWhereClause(rule, check.satisfies(complianceCondition, check.description, _ == 1.0,
-          columns = List(transformedColForSparkSql))))
+          columns = List(transformedColForSparkSql), analyzerOptions = opts)))
 
       case NOT_BETWEEN =>
         val notBetweenSparkSql = s"(length($transformedColForSparkSql) <= ${operands.head}) or " +
@@ -124,7 +133,7 @@ case class ColumnLengthRule() extends DQDLRuleConverter {
           if (operands.contains(0.0)) s"$transformedColForSparkSql is not NULL or ($notBetweenSparkSql)"
           else s"$transformedColForSparkSql is NULL or ($notBetweenSparkSql)"
         Right(addWhereClause(rule, check.satisfies(complianceCondition, check.description, _ == 1.0,
-          columns = List(transformedColForSparkSql))))
+          columns = List(transformedColForSparkSql), analyzerOptions = opts)))
 
       case _ => Left("Unsupported operator for ColumnLength rule.")
     }

--- a/src/main/scala/com/amazon/deequ/dqdl/translation/rules/ColumnValuesRule.scala
+++ b/src/main/scala/com/amazon/deequ/dqdl/translation/rules/ColumnValuesRule.scala
@@ -225,6 +225,9 @@ case class ColumnValuesRule() extends DQDLRuleConverter {
   private def mkStringCheck(check: Check, targetColumn: String, transformedCol: String,
                             condition: StringBasedCondition,
                             rule: DQRule): Either[String, (Check, Seq[DeequMetricMapping])] = {
+    val shouldIgnoreCase = Option(rule.getTags)
+      .flatMap(t => Option(t.get("IGNORE_CASE")))
+      .exists(_.equalsIgnoreCase("true"))
     condition.getOperator match {
       case StringBasedConditionOperator.MATCHES =>
         val pattern = extractPattern(condition)
@@ -245,7 +248,8 @@ case class ColumnValuesRule() extends DQDLRuleConverter {
             "PatternMatch", "PatternMatch", None, rule = rule))))
 
       case StringBasedConditionOperator.IN | StringBasedConditionOperator.EQUALS =>
-        val sql = constructComplianceCondition(transformedCol, condition, isNegated = false)
+        val sql = constructComplianceCondition(transformedCol, condition,
+          isNegated = false, shouldIgnoreCase)
         Right((addWhereClause(rule, check.satisfies(sql,
           check.description, thresholdOrDefault(rule),
           columns = List(transformedCol),
@@ -253,7 +257,8 @@ case class ColumnValuesRule() extends DQDLRuleConverter {
           complianceMetric(targetColumn, check.description, rule)))
 
       case StringBasedConditionOperator.NOT_IN | StringBasedConditionOperator.NOT_EQUALS =>
-        val sql = constructComplianceCondition(transformedCol, condition, isNegated = true)
+        val sql = constructComplianceCondition(transformedCol, condition,
+          isNegated = true, shouldIgnoreCase)
         Right((addWhereClause(rule, check.satisfies(sql,
           check.description, thresholdOrDefault(rule),
           columns = List(transformedCol),
@@ -266,7 +271,8 @@ case class ColumnValuesRule() extends DQDLRuleConverter {
   }
 
   private def constructComplianceCondition(targetColumn: String, condition: StringBasedCondition,
-                                           isNegated: Boolean): String = {
+                                           isNegated: Boolean,
+                                           shouldIgnoreCase: Boolean = false): String = {
     val operands = condition.getOperands.asScala
     val quotedStrings = operands.collect { case q: QuotedStringOperand => q.getOperand }
     val keywordOperands = operands.collect { case k: KeywordStringOperand => k.formatOperand() }
@@ -275,6 +281,7 @@ case class ColumnValuesRule() extends DQDLRuleConverter {
     val hasEmpty = keywordOperands.contains("EMPTY")
     val hasWhitespacesOnly = keywordOperands.contains("WHITESPACES_ONLY")
 
+    val col = if (shouldIgnoreCase) s"lower($targetColumn)" else targetColumn
     val conditions = scala.collection.mutable.ListBuffer[String]()
 
     if (isNegated) {
@@ -284,8 +291,12 @@ case class ColumnValuesRule() extends DQDLRuleConverter {
         conditions += s"($targetColumn IS NULL OR LENGTH(TRIM($targetColumn)) > 0 OR LENGTH($targetColumn) = 0)"
       }
       if (quotedStrings.nonEmpty) {
-        val valueList = quotedStrings.map(s => s"'${s.replace("'", "''")}'").mkString(", ")
-        conditions += s"($targetColumn IS NULL OR $targetColumn NOT IN ($valueList))"
+        val valueList = if (shouldIgnoreCase) {
+          quotedStrings.map(s => s"'${s.replace("'", "''").toLowerCase}'").mkString(", ")
+        } else {
+          quotedStrings.map(s => s"'${s.replace("'", "''")}'").mkString(", ")
+        }
+        conditions += s"($targetColumn IS NULL OR $col NOT IN ($valueList))"
       }
       if (conditions.isEmpty) "TRUE" else conditions.mkString(" AND ")
     } else {
@@ -295,8 +306,12 @@ case class ColumnValuesRule() extends DQDLRuleConverter {
         conditions += s"($targetColumn IS NOT NULL AND LENGTH(TRIM($targetColumn)) = 0 AND LENGTH($targetColumn) > 0)"
       }
       if (quotedStrings.nonEmpty) {
-        val valueList = quotedStrings.map(s => s"'${s.replace("'", "''")}'").mkString(", ")
-        conditions += s"($targetColumn IS NOT NULL AND $targetColumn IN ($valueList))"
+        val valueList = if (shouldIgnoreCase) {
+          quotedStrings.map(s => s"'${s.replace("'", "''").toLowerCase}'").mkString(", ")
+        } else {
+          quotedStrings.map(s => s"'${s.replace("'", "''")}'").mkString(", ")
+        }
+        conditions += s"($targetColumn IS NOT NULL AND $col IN ($valueList))"
       }
       if (conditions.isEmpty) "FALSE" else conditions.mkString(" OR ")
     }

--- a/src/main/scala/com/amazon/deequ/dqdl/translation/rules/ColumnValuesRule.scala
+++ b/src/main/scala/com/amazon/deequ/dqdl/translation/rules/ColumnValuesRule.scala
@@ -16,6 +16,7 @@
 
 package com.amazon.deequ.dqdl.translation.rules
 
+import com.amazon.deequ.analyzers.{AnalyzerOptions, FilteredRowOutcome, NullBehavior}
 import com.amazon.deequ.checks.Check
 import com.amazon.deequ.checks.CheckLevel
 import com.amazon.deequ.dqdl.model.DeequMetricMapping
@@ -71,12 +72,17 @@ case class ColumnValuesRule() extends DQDLRuleConverter {
     val hasNullOperand = rawOperands.exists(_.isInstanceOf[NullNumericOperand])
     val numericOperands = rawOperands.collect { case a: AtomicNumberOperand => a.getOperand.toDouble }
 
+    val opts = analyzerOptionsForWhereClause(rule)
+    val nullFailOpts: Option[AnalyzerOptions] =
+      Some(AnalyzerOptions(NullBehavior.Fail,
+        opts.map(_.filteredRow).getOrElse(FilteredRowOutcome.TRUE)))
+
     condition.getOperator match {
       case GREATER_THAN =>
         val resultCheck = if (isWhereClausePresent(rule)) {
           check
-            .hasMin(targetColumn, _ > numericOperands.head).where(rule.getWhereClause)
-            .isComplete(targetColumn).where(rule.getWhereClause)
+            .hasMin(targetColumn, _ > numericOperands.head, analyzerOptions = opts).where(rule.getWhereClause)
+            .isComplete(targetColumn, None, opts).where(rule.getWhereClause)
         } else {
           check
             .hasMin(targetColumn, _ > numericOperands.head)
@@ -87,8 +93,8 @@ case class ColumnValuesRule() extends DQDLRuleConverter {
       case GREATER_THAN_EQUAL_TO =>
         val resultCheck = if (isWhereClausePresent(rule)) {
           check
-            .hasMin(targetColumn, _ >= numericOperands.head).where(rule.getWhereClause)
-            .isComplete(targetColumn).where(rule.getWhereClause)
+            .hasMin(targetColumn, _ >= numericOperands.head, analyzerOptions = opts).where(rule.getWhereClause)
+            .isComplete(targetColumn, None, opts).where(rule.getWhereClause)
         } else {
           check
             .hasMin(targetColumn, _ >= numericOperands.head)
@@ -99,8 +105,8 @@ case class ColumnValuesRule() extends DQDLRuleConverter {
       case LESS_THAN =>
         val resultCheck = if (isWhereClausePresent(rule)) {
           check
-            .hasMax(targetColumn, _ < numericOperands.head).where(rule.getWhereClause)
-            .isComplete(targetColumn).where(rule.getWhereClause)
+            .hasMax(targetColumn, _ < numericOperands.head, analyzerOptions = opts).where(rule.getWhereClause)
+            .isComplete(targetColumn, None, opts).where(rule.getWhereClause)
         } else {
           check
             .hasMax(targetColumn, _ < numericOperands.head)
@@ -111,8 +117,8 @@ case class ColumnValuesRule() extends DQDLRuleConverter {
       case LESS_THAN_EQUAL_TO =>
         val resultCheck = if (isWhereClausePresent(rule)) {
           check
-            .hasMax(targetColumn, _ <= numericOperands.head).where(rule.getWhereClause)
-            .isComplete(targetColumn).where(rule.getWhereClause)
+            .hasMax(targetColumn, _ <= numericOperands.head, analyzerOptions = opts).where(rule.getWhereClause)
+            .isComplete(targetColumn, None, opts).where(rule.getWhereClause)
         } else {
           check
             .hasMax(targetColumn, _ <= numericOperands.head)
@@ -127,7 +133,7 @@ case class ColumnValuesRule() extends DQDLRuleConverter {
         val resultCheck = if (isWhereClausePresent(rule)) {
           check.isContainedIn(targetColumn, numericOperands.head, numericOperands.last,
             includeLowerBound = false, includeUpperBound = false).where(rule.getWhereClause)
-            .isComplete(targetColumn).where(rule.getWhereClause)
+            .isComplete(targetColumn, None, opts).where(rule.getWhereClause)
         } else {
           check.isContainedIn(targetColumn, numericOperands.head, numericOperands.last,
             includeLowerBound = false, includeUpperBound = false)
@@ -142,7 +148,8 @@ case class ColumnValuesRule() extends DQDLRuleConverter {
         val sql = s"$transformedCol IS NOT NULL AND " +
           s"($transformedCol <= ${numericOperands.head} OR $transformedCol >= ${numericOperands.last})"
         Right((addWhereClause(rule, check.satisfies(sql, check.description, _ == 1.0,
-          columns = List(transformedCol))), complianceMetric(targetColumn, check.description, rule)))
+          columns = List(transformedCol), analyzerOptions = opts)),
+          complianceMetric(targetColumn, check.description, rule)))
 
       case IN =>
         val nums = numericOperands.mkString(", ")
@@ -153,7 +160,8 @@ case class ColumnValuesRule() extends DQDLRuleConverter {
           case _ => "FALSE"
         }
         Right((addWhereClause(rule, check.satisfies(sql, check.description, _ == 1.0,
-          columns = List(transformedCol))), complianceMetric(targetColumn, check.description, rule)))
+          columns = List(transformedCol), analyzerOptions = opts)),
+          complianceMetric(targetColumn, check.description, rule)))
 
       case NOT_IN =>
         val nums = numericOperands.mkString(", ")
@@ -164,23 +172,28 @@ case class ColumnValuesRule() extends DQDLRuleConverter {
           case _ => "TRUE"
         }
         Right((addWhereClause(rule, check.satisfies(sql, check.description, _ == 1.0,
-          columns = List(transformedCol))), complianceMetric(targetColumn, check.description, rule)))
+          columns = List(transformedCol), analyzerOptions = opts)),
+          complianceMetric(targetColumn, check.description, rule)))
 
       case EQUALS =>
         if (hasNullOperand) {
           val sql = s"$transformedCol IS NULL"
           Right((addWhereClause(rule, check.satisfies(sql, check.description, _ == 1.0,
-            columns = List(transformedCol))), complianceMetric(targetColumn, check.description, rule)))
+            columns = List(transformedCol), analyzerOptions = opts)),
+            complianceMetric(targetColumn, check.description, rule)))
         } else {
           val resultCheck = if (isWhereClausePresent(rule)) {
             check
-              .hasMin(targetColumn, _ == numericOperands.head).where(rule.getWhereClause)
-              .hasMax(targetColumn, _ == numericOperands.head).where(rule.getWhereClause)
-              .isComplete(targetColumn).where(rule.getWhereClause)
+              .hasMin(targetColumn, _ == numericOperands.head,
+                analyzerOptions = nullFailOpts).where(rule.getWhereClause)
+              .hasMax(targetColumn, _ == numericOperands.head,
+                analyzerOptions = nullFailOpts).where(rule.getWhereClause)
+              .isComplete(targetColumn, analyzerOptions = opts)
+              .where(rule.getWhereClause)
           } else {
             check
-              .hasMin(targetColumn, _ == numericOperands.head)
-              .hasMax(targetColumn, _ == numericOperands.head)
+              .hasMin(targetColumn, _ == numericOperands.head, analyzerOptions = nullFailOpts)
+              .hasMax(targetColumn, _ == numericOperands.head, analyzerOptions = nullFailOpts)
               .isComplete(targetColumn)
           }
           Right((resultCheck, minMetric(targetColumn, rule) ++ maxMetric(targetColumn, rule)))
@@ -190,11 +203,13 @@ case class ColumnValuesRule() extends DQDLRuleConverter {
         if (hasNullOperand) {
           val sql = s"$transformedCol IS NOT NULL"
           Right((addWhereClause(rule, check.satisfies(sql, check.description, _ == 1.0,
-            columns = List(transformedCol))), complianceMetric(targetColumn, check.description, rule)))
+            columns = List(transformedCol), analyzerOptions = opts)),
+            complianceMetric(targetColumn, check.description, rule)))
         } else {
           val sql = s"$transformedCol IS NULL OR $transformedCol != ${numericOperands.head}"
           Right((addWhereClause(rule, check.satisfies(sql, check.description, _ == 1.0,
-            columns = List(transformedCol))), complianceMetric(targetColumn, check.description, rule)))
+            columns = List(transformedCol), analyzerOptions = opts)),
+            complianceMetric(targetColumn, check.description, rule)))
         }
 
       case _ =>
@@ -209,24 +224,28 @@ case class ColumnValuesRule() extends DQDLRuleConverter {
       case StringBasedConditionOperator.MATCHES =>
         val pattern = extractPattern(condition)
         val fullRegex = s"^${pattern}$$".r
-        Right((addWhereClause(rule, check.hasPattern(targetColumn, fullRegex)),
+        Right((addWhereClause(rule, check.hasPattern(targetColumn, fullRegex,
+          analyzerOptions = analyzerOptionsForWhereClause(rule))),
           Seq(DeequMetricMapping("Column", targetColumn, "PatternMatch", "PatternMatch", None, rule = rule))))
 
       case StringBasedConditionOperator.NOT_MATCHES =>
         val pattern = extractPattern(condition)
         val fullRegex = s"^(?!\\b${pattern}\\b).*$$".r
-        Right((addWhereClause(rule, check.hasPattern(targetColumn, fullRegex)),
+        Right((addWhereClause(rule, check.hasPattern(targetColumn, fullRegex,
+          analyzerOptions = analyzerOptionsForWhereClause(rule))),
           Seq(DeequMetricMapping("Column", targetColumn, "PatternMatch", "PatternMatch", None, rule = rule))))
 
       case StringBasedConditionOperator.IN | StringBasedConditionOperator.EQUALS =>
         val sql = constructComplianceCondition(transformedCol, condition, isNegated = false)
         Right((addWhereClause(rule, check.satisfies(sql, check.description, _ == 1.0,
-          columns = List(transformedCol))), complianceMetric(targetColumn, check.description, rule)))
+          columns = List(transformedCol), analyzerOptions = analyzerOptionsForWhereClause(rule))),
+          complianceMetric(targetColumn, check.description, rule)))
 
       case StringBasedConditionOperator.NOT_IN | StringBasedConditionOperator.NOT_EQUALS =>
         val sql = constructComplianceCondition(transformedCol, condition, isNegated = true)
         Right((addWhereClause(rule, check.satisfies(sql, check.description, _ == 1.0,
-          columns = List(transformedCol))), complianceMetric(targetColumn, check.description, rule)))
+          columns = List(transformedCol), analyzerOptions = analyzerOptionsForWhereClause(rule))),
+          complianceMetric(targetColumn, check.description, rule)))
 
       case _ =>
         Left(s"Unsupported operator for ColumnValues string condition: ${condition.getOperator}")
@@ -247,9 +266,9 @@ case class ColumnValuesRule() extends DQDLRuleConverter {
 
     if (isNegated) {
       if (hasNull) conditions += s"$targetColumn IS NOT NULL"
-      if (hasEmpty) conditions += s"$targetColumn != ''"
+      if (hasEmpty) conditions += s"($targetColumn IS NULL OR $targetColumn != '')"
       if (hasWhitespacesOnly) {
-        conditions += s"(LENGTH(TRIM($targetColumn)) > 0 OR LENGTH($targetColumn) = 0)"
+        conditions += s"($targetColumn IS NULL OR LENGTH(TRIM($targetColumn)) > 0 OR LENGTH($targetColumn) = 0)"
       }
       if (quotedStrings.nonEmpty) {
         val valueList = quotedStrings.map(s => s"'${s.replace("'", "''")}'").mkString(", ")
@@ -258,9 +277,9 @@ case class ColumnValuesRule() extends DQDLRuleConverter {
       if (conditions.isEmpty) "TRUE" else conditions.mkString(" AND ")
     } else {
       if (hasNull) conditions += s"$targetColumn IS NULL"
-      if (hasEmpty) conditions += s"$targetColumn = ''"
+      if (hasEmpty) conditions += s"($targetColumn IS NOT NULL AND $targetColumn = '')"
       if (hasWhitespacesOnly) {
-        conditions += s"(LENGTH(TRIM($targetColumn)) = 0 AND LENGTH($targetColumn) > 0)"
+        conditions += s"($targetColumn IS NOT NULL AND LENGTH(TRIM($targetColumn)) = 0 AND LENGTH($targetColumn) > 0)"
       }
       if (quotedStrings.nonEmpty) {
         val valueList = quotedStrings.map(s => s"'${s.replace("'", "''")}'").mkString(", ")

--- a/src/main/scala/com/amazon/deequ/dqdl/translation/rules/ColumnValuesRule.scala
+++ b/src/main/scala/com/amazon/deequ/dqdl/translation/rules/ColumnValuesRule.scala
@@ -159,7 +159,8 @@ case class ColumnValuesRule() extends DQDLRuleConverter {
           case (false, true) => s"$transformedCol IS NULL"
           case _ => "FALSE"
         }
-        Right((addWhereClause(rule, check.satisfies(sql, check.description, _ == 1.0,
+        Right((addWhereClause(rule, check.satisfies(sql, check.description,
+          thresholdOrDefault(rule),
           columns = List(transformedCol), analyzerOptions = opts)),
           complianceMetric(targetColumn, check.description, rule)))
 
@@ -171,14 +172,16 @@ case class ColumnValuesRule() extends DQDLRuleConverter {
           case (false, true) => s"$transformedCol IS NOT NULL"
           case _ => "TRUE"
         }
-        Right((addWhereClause(rule, check.satisfies(sql, check.description, _ == 1.0,
+        Right((addWhereClause(rule, check.satisfies(sql, check.description,
+          thresholdOrDefault(rule),
           columns = List(transformedCol), analyzerOptions = opts)),
           complianceMetric(targetColumn, check.description, rule)))
 
       case EQUALS =>
         if (hasNullOperand) {
           val sql = s"$transformedCol IS NULL"
-          Right((addWhereClause(rule, check.satisfies(sql, check.description, _ == 1.0,
+          Right((addWhereClause(rule, check.satisfies(sql,
+            check.description, thresholdOrDefault(rule),
             columns = List(transformedCol), analyzerOptions = opts)),
             complianceMetric(targetColumn, check.description, rule)))
         } else {
@@ -202,12 +205,14 @@ case class ColumnValuesRule() extends DQDLRuleConverter {
       case NOT_EQUALS =>
         if (hasNullOperand) {
           val sql = s"$transformedCol IS NOT NULL"
-          Right((addWhereClause(rule, check.satisfies(sql, check.description, _ == 1.0,
+          Right((addWhereClause(rule, check.satisfies(sql,
+            check.description, thresholdOrDefault(rule),
             columns = List(transformedCol), analyzerOptions = opts)),
             complianceMetric(targetColumn, check.description, rule)))
         } else {
           val sql = s"$transformedCol IS NULL OR $transformedCol != ${numericOperands.head}"
-          Right((addWhereClause(rule, check.satisfies(sql, check.description, _ == 1.0,
+          Right((addWhereClause(rule, check.satisfies(sql,
+            check.description, thresholdOrDefault(rule),
             columns = List(transformedCol), analyzerOptions = opts)),
             complianceMetric(targetColumn, check.description, rule)))
         }
@@ -224,27 +229,35 @@ case class ColumnValuesRule() extends DQDLRuleConverter {
       case StringBasedConditionOperator.MATCHES =>
         val pattern = extractPattern(condition)
         val fullRegex = s"^${pattern}$$".r
-        Right((addWhereClause(rule, check.hasPattern(targetColumn, fullRegex,
+        Right((addWhereClause(rule, check.hasPattern(targetColumn,
+          fullRegex, thresholdOrDefault(rule),
           analyzerOptions = analyzerOptionsForWhereClause(rule))),
-          Seq(DeequMetricMapping("Column", targetColumn, "PatternMatch", "PatternMatch", None, rule = rule))))
+          Seq(DeequMetricMapping("Column", targetColumn,
+            "PatternMatch", "PatternMatch", None, rule = rule))))
 
       case StringBasedConditionOperator.NOT_MATCHES =>
         val pattern = extractPattern(condition)
         val fullRegex = s"^(?!\\b${pattern}\\b).*$$".r
-        Right((addWhereClause(rule, check.hasPattern(targetColumn, fullRegex,
+        Right((addWhereClause(rule, check.hasPattern(targetColumn,
+          fullRegex, thresholdOrDefault(rule),
           analyzerOptions = analyzerOptionsForWhereClause(rule))),
-          Seq(DeequMetricMapping("Column", targetColumn, "PatternMatch", "PatternMatch", None, rule = rule))))
+          Seq(DeequMetricMapping("Column", targetColumn,
+            "PatternMatch", "PatternMatch", None, rule = rule))))
 
       case StringBasedConditionOperator.IN | StringBasedConditionOperator.EQUALS =>
         val sql = constructComplianceCondition(transformedCol, condition, isNegated = false)
-        Right((addWhereClause(rule, check.satisfies(sql, check.description, _ == 1.0,
-          columns = List(transformedCol), analyzerOptions = analyzerOptionsForWhereClause(rule))),
+        Right((addWhereClause(rule, check.satisfies(sql,
+          check.description, thresholdOrDefault(rule),
+          columns = List(transformedCol),
+          analyzerOptions = analyzerOptionsForWhereClause(rule))),
           complianceMetric(targetColumn, check.description, rule)))
 
       case StringBasedConditionOperator.NOT_IN | StringBasedConditionOperator.NOT_EQUALS =>
         val sql = constructComplianceCondition(transformedCol, condition, isNegated = true)
-        Right((addWhereClause(rule, check.satisfies(sql, check.description, _ == 1.0,
-          columns = List(transformedCol), analyzerOptions = analyzerOptionsForWhereClause(rule))),
+        Right((addWhereClause(rule, check.satisfies(sql,
+          check.description, thresholdOrDefault(rule),
+          columns = List(transformedCol),
+          analyzerOptions = analyzerOptionsForWhereClause(rule))),
           complianceMetric(targetColumn, check.description, rule)))
 
       case _ =>
@@ -376,12 +389,17 @@ case class ColumnValuesRule() extends DQDLRuleConverter {
     }
   }
 
-  private def parseThresholdAssertion(rule: DQRule): Option[Double => Boolean] = {
+  private def parseThresholdAssertion(
+    rule: DQRule): Option[Double => Boolean] = {
     Option(rule.getThresholdCondition)
       .filter(_.getConditionAsString.nonEmpty)
       .map(_.asInstanceOf[NumberBasedCondition])
       .map(t => assertionAsScala(rule, t))
   }
+
+  private def thresholdOrDefault(
+    rule: DQRule): Double => Boolean =
+    parseThresholdAssertion(rule).getOrElse(Check.IsOne)
 
   private def minMetric(targetColumn: String, rule: DQRule): Seq[DeequMetricMapping] =
     Seq(DeequMetricMapping("Column", targetColumn, "Minimum", "Minimum", None, rule = rule))

--- a/src/main/scala/com/amazon/deequ/dqdl/translation/rules/CompletenessRule.scala
+++ b/src/main/scala/com/amazon/deequ/dqdl/translation/rules/CompletenessRule.scala
@@ -29,7 +29,8 @@ case class CompletenessRule() extends DQDLRuleConverter {
   override def convert(rule: DQRule): Either[String, (Check, Seq[DeequMetricMapping])] = {
     val col = rule.getParameters.asScala("TargetColumn")
     val check = Check(CheckLevel.Error, java.util.UUID.randomUUID.toString)
-      .hasCompleteness(col, assertionAsScala(rule, rule.getCondition.asInstanceOf[NumberBasedCondition]), None, None)
+      .hasCompleteness(col, assertionAsScala(rule, rule.getCondition.asInstanceOf[NumberBasedCondition]),
+        None, analyzerOptionsForWhereClause(rule))
     Right(
       addWhereClause(rule, check),
       Seq(DeequMetricMapping("Column", col, "Completeness", "Completeness", None, rule = rule)))

--- a/src/main/scala/com/amazon/deequ/dqdl/translation/rules/EntropyRule.scala
+++ b/src/main/scala/com/amazon/deequ/dqdl/translation/rules/EntropyRule.scala
@@ -19,7 +19,6 @@ package com.amazon.deequ.dqdl.translation.rules
 import com.amazon.deequ.checks.{Check, CheckLevel}
 import com.amazon.deequ.dqdl.model.DeequMetricMapping
 import com.amazon.deequ.dqdl.translation.DQDLRuleConverter
-import com.amazon.deequ.dqdl.util.DQDLUtility.addWhereClause
 import software.amazon.glue.dqdl.model.DQRule
 import software.amazon.glue.dqdl.model.condition.number.NumberBasedCondition
 
@@ -31,7 +30,7 @@ case class EntropyRule() extends DQDLRuleConverter {
     val check = Check(CheckLevel.Error, java.util.UUID.randomUUID.toString)
       .hasEntropy(col, assertionAsScala(rule, rule.getCondition.asInstanceOf[NumberBasedCondition]))
     Right(
-      addWhereClause(rule, check),
+      check,
       Seq(DeequMetricMapping("Column", col, "Entropy", "Entropy", None, rule = rule)))
   }
 }

--- a/src/main/scala/com/amazon/deequ/dqdl/translation/rules/IsCompleteRule.scala
+++ b/src/main/scala/com/amazon/deequ/dqdl/translation/rules/IsCompleteRule.scala
@@ -28,7 +28,8 @@ import scala.collection.JavaConverters._
 case class IsCompleteRule() extends DQDLRuleConverter {
   override def convert(rule: DQRule): Either[String, (Check, Seq[DeequMetricMapping])] = {
     val col = rule.getParameters.asScala("TargetColumn")
-    val check = Check(CheckLevel.Error, java.util.UUID.randomUUID.toString).isComplete(col)
+    val check = Check(CheckLevel.Error, java.util.UUID.randomUUID.toString)
+      .isComplete(col, None, analyzerOptionsForWhereClause(rule))
     Right(
       addWhereClause(rule, check),
       Seq(DeequMetricMapping("Column", col, "Completeness", "Completeness", None, rule = rule)))

--- a/src/main/scala/com/amazon/deequ/dqdl/translation/rules/IsPrimaryKeyRule.scala
+++ b/src/main/scala/com/amazon/deequ/dqdl/translation/rules/IsPrimaryKeyRule.scala
@@ -29,10 +29,12 @@ case class IsPrimaryKeyRule() extends DQDLRuleConverter {
   override def convert(rule: DQRule): Either[String, (Check, Seq[DeequMetricMapping])] = {
     val columns = rule.getParameters.asScala.collect { case (k, v) if k.startsWith("TargetColumn") => v }.toSeq
     val check = Check(CheckLevel.Error, java.util.UUID.randomUUID.toString)
+    val opts = analyzerOptionsForWhereClause(rule)
     columns match {
       case Nil => Left("Required parameters not found")
       case Seq(singleCol) =>
-        val singleColCheck = addWhereClause(rule, check.isPrimaryKey(singleCol, None)).isComplete(singleCol, None)
+        val singleColCheck = addWhereClause(rule, check.isPrimaryKey(singleCol, None, opts))
+          .isComplete(singleCol, None, opts)
         Right(
           addWhereClause(rule, singleColCheck),
           Seq(
@@ -41,15 +43,15 @@ case class IsPrimaryKeyRule() extends DQDLRuleConverter {
           )
         )
       case cols@(head +: tail) =>
-        val multiColCheck = addWhereClause(rule, check.isPrimaryKey(head, None, tail: _*))
-        cols.foldLeft(multiColCheck) {
-          (mc, col) => addWhereClause(rule, mc.isComplete(col))
+        val multiColCheck = addWhereClause(rule, check.isPrimaryKey(head, None, opts, tail: _*))
+        val withCompleteness = cols.foldLeft(multiColCheck) {
+          (mc, col) => addWhereClause(rule, mc.isComplete(col, None, opts))
         }
         val completenessMetricMappings = cols.map(
           col => DeequMetricMapping("Column", col, "Completeness", "Completeness", None, rule = rule)
         )
         Right(
-          multiColCheck,
+          withCompleteness,
           Seq(DeequMetricMapping("Multicolumn", cols.mkString(","), "Uniqueness", "Uniqueness", None, rule = rule))
             ++ completenessMetricMappings
         )

--- a/src/main/scala/com/amazon/deequ/dqdl/translation/rules/IsUniqueRule.scala
+++ b/src/main/scala/com/amazon/deequ/dqdl/translation/rules/IsUniqueRule.scala
@@ -33,12 +33,12 @@ case class IsUniqueRule() extends DQDLRuleConverter {
       case Nil => Left("Required parameters not found")
 
       case Seq(singleCol) =>
-        val singleColCheck = check.isUnique(singleCol)
+        val singleColCheck = check.isUnique(singleCol, analyzerOptions = analyzerOptionsForWhereClause(rule))
         Right((addWhereClause(rule, singleColCheck),
           Seq(DeequMetricMapping("Column", singleCol, "Uniqueness", "Uniqueness", None, rule = rule))))
 
       case cols@(head +: tail) =>
-        val multiColCheck = check.areUnique(columns)
+        val multiColCheck = check.areUnique(columns, analyzerOptions = analyzerOptionsForWhereClause(rule))
         Right(
           addWhereClause(rule, multiColCheck),
           Seq(DeequMetricMapping("Multicolumn", columns.mkString(","), "Uniqueness", "Uniqueness", None, rule = rule)))

--- a/src/main/scala/com/amazon/deequ/dqdl/translation/rules/UniqueValueRatioRule.scala
+++ b/src/main/scala/com/amazon/deequ/dqdl/translation/rules/UniqueValueRatioRule.scala
@@ -29,7 +29,8 @@ case class UniqueValueRatioRule() extends DQDLRuleConverter {
   override def convert(rule: DQRule): Either[String, (Check, Seq[DeequMetricMapping])] = {
     val col = rule.getParameters.asScala("TargetColumn")
     val check = Check(CheckLevel.Error, java.util.UUID.randomUUID.toString)
-      .hasUniqueValueRatio(Seq(col), assertionAsScala(rule, rule.getCondition.asInstanceOf[NumberBasedCondition]))
+      .hasUniqueValueRatio(Seq(col), assertionAsScala(rule, rule.getCondition.asInstanceOf[NumberBasedCondition]),
+        analyzerOptions = analyzerOptionsForWhereClause(rule))
     Right(
       addWhereClause(rule, check),
       Seq(DeequMetricMapping("Column", col, "UniqueValueRatio", "UniqueValueRatio", None, rule = rule)))

--- a/src/main/scala/com/amazon/deequ/dqdl/translation/rules/UniquenessRule.scala
+++ b/src/main/scala/com/amazon/deequ/dqdl/translation/rules/UniquenessRule.scala
@@ -36,13 +36,15 @@ case class UniquenessRule() extends DQDLRuleConverter {
 
       case Seq(singleCol) =>
         val singleColCheck = check
-          .hasUniqueness(singleCol, assertionAsScala(rule, rule.getCondition.asInstanceOf[NumberBasedCondition]))
+          .hasUniqueness(singleCol, assertionAsScala(rule, rule.getCondition.asInstanceOf[NumberBasedCondition]),
+            None, analyzerOptionsForWhereClause(rule))
         Right((addWhereClause(rule, singleColCheck),
           Seq(DeequMetricMapping("Column", singleCol, "Uniqueness", "Uniqueness", None, rule = rule))))
 
       case cols@(head +: tail) =>
         val multiColCheck = check
-          .hasUniqueness(columns, assertionAsScala(rule, rule.getCondition.asInstanceOf[NumberBasedCondition]))
+          .hasUniqueness(columns, assertionAsScala(rule, rule.getCondition.asInstanceOf[NumberBasedCondition]),
+            None, analyzerOptionsForWhereClause(rule))
         Right(
           addWhereClause(rule, multiColCheck),
           Seq(DeequMetricMapping("Multicolumn", columns.mkString(","), "Uniqueness", "Uniqueness", None, rule = rule)))

--- a/src/test/scala/com/amazon/deequ/dqdl/AnalyzerOptionParitySpec.scala
+++ b/src/test/scala/com/amazon/deequ/dqdl/AnalyzerOptionParitySpec.scala
@@ -290,5 +290,36 @@ class AnalyzerOptionParitySpec extends AnyWordSpec
           """where "grp = 'a'" with threshold > 0.5]"""
         ) should be("Passed")
       }
+
+    "match case-insensitively with IGNORE_CASE tag" in
+      withSparkSession { sparkSession =>
+        import sparkSession.implicits._
+        // "Active" and "ACTIVE" should match "active" with IGNORE_CASE
+        val df = Seq(
+          (1, "Active"), (2, "ACTIVE"), (3, "active"),
+          (4, "deleted")
+        ).toDF("id", "status")
+
+        outcomeOf(df,
+          """Rules=[ColumnValues "status" in ["active"] """ +
+          """with IGNORE_CASE = "true" with threshold > 0.5]"""
+        ) should be("Passed")
+      }
+
+    "apply IGNORE_CASE only to quoted strings, not keywords" in
+      withSparkSession { sparkSession =>
+        import sparkSession.implicits._
+        // NULL rows should still be handled by keyword logic, not lowercased
+        val df = Seq(
+          (1, Some("Active")), (2, Some("ACTIVE")),
+          (3, None), (4, Some("deleted"))
+        ).toDF("id", "status")
+
+        // in ["active", NULL] with IGNORE_CASE: rows 1,2,3 match -> 75%
+        outcomeOf(df,
+          """Rules=[ColumnValues "status" in ["active", NULL] """ +
+          """with IGNORE_CASE = "true" with threshold > 0.5]"""
+        ) should be("Passed")
+      }
   }
 }

--- a/src/test/scala/com/amazon/deequ/dqdl/AnalyzerOptionParitySpec.scala
+++ b/src/test/scala/com/amazon/deequ/dqdl/AnalyzerOptionParitySpec.scala
@@ -1,0 +1,213 @@
+/**
+ * Copyright 2026 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may not
+ * use this file except in compliance with the License. A copy of the License
+ * is located at
+ *
+ * http://aws.amazon.com/apache2.0/
+ *
+ * or in the "license" file accompanying this file. This file is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ */
+
+package com.amazon.deequ.dqdl
+
+import com.amazon.deequ.SparkContextSpec
+import com.amazon.deequ.utils.FixtureSupport
+import org.apache.spark.sql.DataFrame
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+
+/**
+ * Verifies behavioral parity between Deequ's DQDL rule converters
+ * and AwsGlueMlDataQualityETL's DQRuleTranslator for edge cases
+ * involving NULLs, where clauses, and keyword operands.
+ */
+class AnalyzerOptionParitySpec extends AnyWordSpec
+  with Matchers with SparkContextSpec with FixtureSupport {
+
+  private def outcomeOf(df: DataFrame, ruleset: String): String = {
+    val results = EvaluateDataQuality.process(df, ruleset)
+    results.collect().head.getAs[String]("Outcome")
+  }
+
+  private def outcomesOf(df: DataFrame, ruleset: String): Seq[String] = {
+    val results = EvaluateDataQuality.process(df, ruleset)
+    results.collect().map(_.getAs[String]("Outcome")).toSeq
+  }
+
+  "ColumnLength" should {
+
+    "treat NULL as length 0 via NullBehavior.EmptyString" in
+      withSparkSession { sparkSession =>
+        import sparkSession.implicits._
+        // EmptyString: NULL -> length 0, so min = 0, fails >= 2
+        // Without EmptyString: NULL ignored, min = 2, would pass
+        val df = Seq(
+          (1, Some("ab")), (2, Some("abc")), (3, None)
+        ).toDF("id", "val")
+
+        outcomeOf(df,
+          """Rules=[ColumnLength "val" >= 2]""") should be("Failed")
+      }
+
+    "treat NULL as length 0 with where clause" in
+      withSparkSession { sparkSession =>
+        import sparkSession.implicits._
+        val df = Seq(
+          (1, "a", Some("ab")), (2, "a", None), (3, "b", Some("x"))
+        ).toDF("id", "grp", "val")
+
+        outcomeOf(df,
+          """Rules=[ColumnLength "val" >= 2 where "grp = 'a'"]"""
+        ) should be("Failed")
+      }
+  }
+
+  "ColumnValues numeric EQUALS" should {
+
+    "fail when NULLs present via NullBehavior.Fail" in
+      withSparkSession { sparkSession =>
+        import sparkSession.implicits._
+        // NullBehavior.Fail: NULL -> extreme value in min/max
+        val df = Seq(
+          (1, Some(5)), (2, Some(5)), (3, None)
+        ).toDF("id", "val")
+
+        outcomeOf(df,
+          """Rules=[ColumnValues "val" = 5]""") should be("Failed")
+      }
+
+    "pass when no NULLs and all values match" in
+      withSparkSession { sparkSession =>
+        import sparkSession.implicits._
+        val df = Seq(
+          (1, 5), (2, 5), (3, 5)
+        ).toDF("id", "val")
+
+        outcomeOf(df,
+          """Rules=[ColumnValues "val" = 5]""") should be("Passed")
+      }
+  }
+
+  "Entropy" should {
+
+    "compute over all rows ignoring where clause" in
+      withSparkSession { sparkSession =>
+        import sparkSession.implicits._
+        // ETL does not apply where clause for Entropy
+        val df = Seq(
+          (1, "a", "x"), (2, "a", "y"),
+          (3, "b", "x"), (4, "b", "y")
+        ).toDF("id", "grp", "val")
+
+        outcomeOf(df,
+          """Rules=[Entropy "val" > 0.5 where "grp = 'a'"]"""
+        ) should be("Passed")
+      }
+  }
+
+  "ColumnValues string EMPTY keyword" should {
+
+    "not match NULL rows via NULL guard" in
+      withSparkSession { sparkSession =>
+        import sparkSession.implicits._
+        // SQL: (val IS NOT NULL AND val = '')
+        // Only row 1 matches -> 1/3 compliance -> fails
+        val df = Seq(
+          (1, Some("")), (2, None), (3, Some("hello"))
+        ).toDF("id", "val")
+
+        outcomeOf(df,
+          """Rules=[ColumnValues "val" in [EMPTY]]"""
+        ) should be("Failed")
+      }
+
+    "include NULL as passing in negated condition" in
+      withSparkSession { sparkSession =>
+        import sparkSession.implicits._
+        // SQL: (val IS NULL OR val != '')
+        // Row 1 ("") fails, row 2 (null) passes, row 3 passes
+        // -> 2/3 compliance -> fails default threshold 1.0
+        val df = Seq(
+          (1, Some("")), (2, None), (3, Some("hello"))
+        ).toDF("id", "val")
+
+        outcomeOf(df,
+          """Rules=[ColumnValues "val" not in [EMPTY]]"""
+        ) should be("Failed")
+      }
+  }
+
+  "ColumnValues string WHITESPACES_ONLY keyword" should {
+
+    "include NULL as passing in negated condition" in
+      withSparkSession { sparkSession =>
+        import sparkSession.implicits._
+        // SQL: (val IS NULL OR LENGTH(TRIM(val)) > 0 OR LENGTH(val) = 0)
+        // Row 1 ("  ") fails, row 2 (null) passes, row 3 passes
+        // -> 2/3 compliance -> fails default threshold 1.0
+        val df = Seq(
+          (1, Some("  ")), (2, None), (3, Some("hello"))
+        ).toDF("id", "val")
+
+        outcomeOf(df,
+          """Rules=[ColumnValues "val" not in [WHITESPACES_ONLY]]"""
+        ) should be("Failed")
+      }
+  }
+
+  "Where clause filtering" should {
+
+    "scope Completeness to matching rows only" in
+      withSparkSession { sparkSession =>
+        import sparkSession.implicits._
+        // grp='a': 3 rows, 1 null -> completeness 2/3
+        val df = Seq(
+          (1, "a", Some("x")), (2, "a", Some("y")),
+          (3, "a", None), (4, "b", Some("z"))
+        ).toDF("id", "grp", "val")
+
+        outcomeOf(df,
+          """Rules=[Completeness "val" > 0.5 where "grp = 'a'"]"""
+        ) should be("Passed")
+
+        outcomeOf(df,
+          """Rules=[Completeness "val" > 0.8 where "grp = 'a'"]"""
+        ) should be("Failed")
+      }
+
+    "scope IsPrimaryKey to matching rows only" in
+      withSparkSession { sparkSession =>
+        import sparkSession.implicits._
+        // val unique within grp='a' but duplicated across groups
+        val df = Seq(
+          (1, "a", "x"), (2, "a", "y"), (3, "b", "x")
+        ).toDF("id", "grp", "val")
+
+        outcomeOf(df,
+          """Rules=[IsPrimaryKey "val" where "grp = 'a'"]"""
+        ) should be("Passed")
+      }
+
+    "handle multiple rules with mixed where clauses" in
+      withSparkSession { sparkSession =>
+        import sparkSession.implicits._
+        val df = Seq(
+          (1, "a", 10), (2, "a", 20),
+          (3, "b", -5), (4, "b", 15)
+        ).toDF("id", "grp", "val")
+
+        val results = outcomesOf(df,
+          """Rules=[ColumnValues "val" > 0 where "grp = 'a'",""" +
+          """ IsComplete "id", RowCount > 2]""")
+
+        results should have size 3
+        results.foreach(_ should be("Passed"))
+      }
+  }
+}

--- a/src/test/scala/com/amazon/deequ/dqdl/AnalyzerOptionParitySpec.scala
+++ b/src/test/scala/com/amazon/deequ/dqdl/AnalyzerOptionParitySpec.scala
@@ -210,4 +210,85 @@ class AnalyzerOptionParitySpec extends AnyWordSpec
         results.foreach(_ should be("Passed"))
       }
   }
+
+  "ColumnValues with threshold" should {
+
+    "pass string IN when compliance exceeds threshold" in
+      withSparkSession { sparkSession =>
+        import sparkSession.implicits._
+        // 3 of 4 rows match -> 75% compliance
+        // threshold > 0.5 -> should pass
+        val df = Seq(
+          (1, "active"), (2, "active"), (3, "active"),
+          (4, "deleted")
+        ).toDF("id", "status")
+
+        outcomeOf(df,
+          """Rules=[ColumnValues "status" in ["active"] """ +
+          """with threshold > 0.5]"""
+        ) should be("Passed")
+      }
+
+    "fail string IN when compliance below threshold" in
+      withSparkSession { sparkSession =>
+        import sparkSession.implicits._
+        // 3 of 4 rows match -> 75% compliance
+        // threshold > 0.8 -> should fail
+        val df = Seq(
+          (1, "active"), (2, "active"), (3, "active"),
+          (4, "deleted")
+        ).toDF("id", "status")
+
+        outcomeOf(df,
+          """Rules=[ColumnValues "status" in ["active"] """ +
+          """with threshold > 0.8]"""
+        ) should be("Failed")
+      }
+
+    "pass matches when compliance exceeds threshold" in
+      withSparkSession { sparkSession =>
+        import sparkSession.implicits._
+        // 3 of 4 rows match pattern -> 75%
+        val df = Seq(
+          (1, "abc"), (2, "def"), (3, "ghi"), (4, "123")
+        ).toDF("id", "val")
+
+        outcomeOf(df,
+          """Rules=[ColumnValues "val" matches "[a-z]+" """ +
+          """with threshold > 0.5]"""
+        ) should be("Passed")
+      }
+
+    "pass with threshold between range" in
+      withSparkSession { sparkSession =>
+        import sparkSession.implicits._
+        // 3 of 4 match -> 75%
+        // threshold between 0.5 and 0.9 -> 0.75 is in range
+        val df = Seq(
+          (1, "active"), (2, "active"), (3, "active"),
+          (4, "deleted")
+        ).toDF("id", "status")
+
+        outcomeOf(df,
+          """Rules=[ColumnValues "status" in ["active"] """ +
+          """with threshold between 0.5 and 0.9]"""
+        ) should be("Passed")
+      }
+
+    "work with threshold and where clause together" in
+      withSparkSession { sparkSession =>
+        import sparkSession.implicits._
+        // grp='a': 3 rows, 2 match "active" -> 67%
+        // threshold > 0.5 -> should pass
+        val df = Seq(
+          (1, "a", "active"), (2, "a", "active"),
+          (3, "a", "deleted"), (4, "b", "deleted")
+        ).toDF("id", "grp", "status")
+
+        outcomeOf(df,
+          """Rules=[ColumnValues "status" in ["active"] """ +
+          """where "grp = 'a'" with threshold > 0.5]"""
+        ) should be("Passed")
+      }
+  }
 }

--- a/src/test/scala/com/amazon/deequ/dqdl/translation/rules/ColumnValuesRuleSpec.scala
+++ b/src/test/scala/com/amazon/deequ/dqdl/translation/rules/ColumnValuesRuleSpec.scala
@@ -133,8 +133,10 @@ class ColumnValuesRuleSpec extends AnyWordSpec with Matchers {
       result.isRight shouldBe true
       val (check, _) = result.right.get
       check.constraints.size shouldBe 3
-      check.constraints(0).toString shouldBe "MinimumConstraint(Minimum(flag,None,None))"
-      check.constraints(1).toString shouldBe "MaximumConstraint(Maximum(flag,None,None))"
+      check.constraints(0).toString shouldBe
+        "MinimumConstraint(Minimum(flag,None,Some(AnalyzerOptions(Fail,TRUE))))"
+      check.constraints(1).toString shouldBe
+        "MaximumConstraint(Maximum(flag,None,Some(AnalyzerOptions(Fail,TRUE))))"
       check.constraints(2).toString shouldBe "CompletenessConstraint(Completeness(flag,None,None))"
     }
 
@@ -211,7 +213,7 @@ class ColumnValuesRuleSpec extends AnyWordSpec with Matchers {
       val (check, _) = result.right.get
       check.constraints.size shouldBe 1
       check.constraints(0).toString should include(
-        "(LENGTH(TRIM(description)) = 0 AND LENGTH(description) > 0)")
+        "(description IS NOT NULL AND LENGTH(TRIM(description)) = 0 AND LENGTH(description) > 0)")
     }
 
     "convert string NOT IN with NULL keyword (NULLs should fail)" in {
@@ -260,7 +262,7 @@ class ColumnValuesRuleSpec extends AnyWordSpec with Matchers {
       val (check, _) = result.right.get
       check.constraints.size shouldBe 1
       check.constraints(0).toString should include(
-        "(LENGTH(TRIM(description)) > 0 OR LENGTH(description) = 0)")
+        "(description IS NULL OR LENGTH(TRIM(description)) > 0 OR LENGTH(description) = 0)")
     }
 
     "handle string IN with commas inside operand values" in {
@@ -525,7 +527,7 @@ class ColumnValuesRuleSpec extends AnyWordSpec with Matchers {
       result.isRight shouldBe true
       val (check, _) = result.right.get
       check.constraints(0).toString should include(
-        "(LENGTH(TRIM(description)) > 0 OR LENGTH(description) = 0)")
+        "(description IS NULL OR LENGTH(TRIM(description)) > 0 OR LENGTH(description) = 0)")
     }
 
     "IN WHITESPACES_ONLY should fail for empty string" in {
@@ -541,7 +543,7 @@ class ColumnValuesRuleSpec extends AnyWordSpec with Matchers {
       result.isRight shouldBe true
       val (check, _) = result.right.get
       check.constraints(0).toString should include(
-        "(LENGTH(TRIM(description)) = 0 AND LENGTH(description) > 0)")
+        "(description IS NOT NULL AND LENGTH(TRIM(description)) = 0 AND LENGTH(description) > 0)")
     }
 
     "return error for empty numeric operands" in {

--- a/src/test/scala/com/amazon/deequ/dqdl/translation/rules/ColumnValuesRuleSpec.scala
+++ b/src/test/scala/com/amazon/deequ/dqdl/translation/rules/ColumnValuesRuleSpec.scala
@@ -986,5 +986,27 @@ class ColumnValuesRuleSpec extends AnyWordSpec with Matchers {
       result.isLeft shouldBe true
       result.left.get should include("Invalid date operand")
     }
+
+    "use threshold assertion for string IN when threshold specified" in {
+      val parameters = Map("TargetColumn" -> "status")
+      val operands: java.util.List[StringOperand] =
+        List[StringOperand](new QuotedStringOperand("active")).asJava
+      val condition = new StringBasedCondition("in [\"active\"]",
+        StringBasedConditionOperator.IN, operands)
+      val thresholdOperands: java.util.List[NumericOperand] =
+        List[NumericOperand](new AtomicNumberOperand("0.8")).asJava
+      val threshold = new NumberBasedCondition("> 0.8",
+        NumberBasedConditionOperator.GREATER_THAN, thresholdOperands)
+      val rule = new DQRule("ColumnValues", parameters.asJava,
+        condition, threshold, null, null, null)
+
+      val result = ColumnValuesRule().convert(rule)
+
+      result.isRight shouldBe true
+      val (check, _) = result.right.get
+      check.constraints.size shouldBe 1
+      val desc = check.constraints(0).toString
+      desc should include("Compliance")
+    }
   }
 }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
This PR fixes how AnalyzerOptions are passed to Deequ Check methods in the DQDL rule converters, ensuring correct NULL handling when WHERE clauses are present.

*Why was this necessary:*                                                                                                                         
Without this fix, DQDL rule converters pass no `AnalyzerOptions` to Deequ Check methods, defaulting to `NullBehavior.Ignore`. This causes:
- `WHERE` clause rules to compute incorrect metrics (filtered NULLs silently ignored instead of treated as empty strings)
- ColumnLength to ignore NULLs instead of treating them as length 0
- ColumnValues EQUALS to ignore NULLs instead of failing the assertion
- Entropy to incorrectly filter rows when a `WHERE` clause is present (Entropy is a global metric)
- `EMPTY/WHITESPACES_ONLY` keywords to produce SQL without NULL guards, causing incorrect compliance ratios when NULLs are present
                                                                                                                                                                                     
*Changes:*                                                                                                                                                                             
                                                                                                                                                                                     
- `DQDLRuleConverter.scala`: Add `DEFAULT_ANALYZER_OPTION` constant and `analyzerOptionsForWhereClause()` helper                                                                     
- `CompletenessRule`, `IsCompleteRule`, `UniquenessRule`, `IsUniqueRule`, `UniqueValueRatioRule`: Pass AnalyzerOptions when WHERE clause present                                     
- `IsPrimaryKeyRule`: Pass AnalyzerOptions + fix multi-column bug where completeness constraints were silently dropped                                                               
- `ColumnLengthRule`: Pass AnalyzerOptions unconditionally (NULLs treated as length 0)                                                                                               
- `ColumnValuesRule`: Pass AnalyzerOptions for WHERE clause; use `NullBehavior.Fail` for EQUALS min/max; add NULL guards for `EMPTY` and `WHITESPACES_ONLY` keywords in generated SQL    
- `EntropyRule`: Remove WHERE clause filtering (global metric should not be filtered)                                                                                                
- `ColumnValuesRuleSpec`: Update 5 existing tests for new constraint representations                                                                                                 
- `AnalyzerOptionParitySpec` (new): 11 integration tests covering all changes                                                                                                        
                                                                                                                                                                                     
All 1020 tests pass.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
